### PR TITLE
Avoid exception, enable source-map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,10 +23,14 @@ import NotFoundComponent from 'components/NotFound';
 
 let store = createStore(
   combineReducers(reducers),
-  compose(
-    applyMiddleware(thunk),
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-  )
+  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+    compose(
+      applyMiddleware(thunk),
+      window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__()
+    ) :
+    compose(
+      applyMiddleware(thunk),
+    )
 );
 
 ReactDOM.render(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,7 @@ module.exports = {
       'node_modules'
     ]
   },
+  devtool: 'source-map',
   devServer: {
     publicPath: '/',
     contentBase: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
- Avoid throwing an exception when redux devtools are not installed
- Enable source-map